### PR TITLE
fix(mcp): expose tool arguments on request so gateway can resolve path params

### DIFF
--- a/libs/api-gateway/mcp/services/mcp-tool-executor.service.ts
+++ b/libs/api-gateway/mcp/services/mcp-tool-executor.service.ts
@@ -42,6 +42,13 @@ export class McpToolExecutorService {
         }
 
         try {
+            // The gateway runs with body parsing disabled and the MCP SDK consumes the raw
+            // request stream itself, so `request.body` is never populated for `/mcp`. Expose the
+            // tool arguments (e.g. `path_projectId`) on the request so gateway middleware — most
+            // importantly the project-permission check — can resolve path parameters the same way
+            // it does for a normal REST request.
+            (request as any).body = args;
+
             await this.throttlerService.checkLimitOfRequest(tool.routerDetail, request as any);
 
             const proxyRequest = new ProxyRequest();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@hodfords/nestjs-api-gateway",
-    "version": "11.0.37",
+    "version": "11.0.38",
     "description": "The API Gateway houses the source code and documentation for the API Gateway - a powerful and versatile solution for managing and deploying APIs within a distributed and microservices-oriented architecture.",
     "author": "",
     "private": false,


### PR DESCRIPTION
## Problem
MCP tool calls to project-scoped endpoints (`/projects/:projectId/...` guarded by `@ProjectPermission`) fail at the gateway with `Uuid Exception`.

The gateway runs with `bodyParser: false` and the MCP SDK consumes the raw request stream, so `request.body` is never populated for `/mcp`. Gateway middleware that resolves route path parameters — most importantly the project-permission check — reads from `request.url` (`/mcp`) / `request.body` and therefore cannot find params such as `path_projectId`. `isUUID(undefined)` then throws.

This blocks every project-scoped tool (Sprint, Board, etc.) while non-project tools (projectId passed as a query param) work fine.

## Fix
Attach the parsed tool arguments to `request.body` in `McpToolExecutorService.executeTool` **before** running the gateway middleware pipeline, so path parameters (`path_projectId`, …) resolve the same way they do for a normal REST request.

```ts
(request as any).body = args;
await this.throttlerService.checkLimitOfRequest(tool.routerDetail, request);
const isAllowed = await this.requestService.handle(tool.routerDetail, request, proxyRequest);
```

`args` is unchanged for the downstream forward (`forwardToService` uses `args` directly), and no other consumer reads `request.body` on the `/mcp` path, so this is side-effect free.

## Downstream
The consumer's gateway authorization service reads `request.body['path_<param>']` to resolve the project id; with this change it gets the real value and enforces the project permission (instead of failing or skipping it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)