### PR TITLE
fix(proxy): replay upgrade head so the first websocket frame is not dropped

### DIFF
--- a/libs/api-gateway/proxy/proxy-server.ts
+++ b/libs/api-gateway/proxy/proxy-server.ts
@@ -60,9 +60,13 @@ export class ProxyServer {
         return requestHeaders;
     }
 
-    async forwardWebsocket(req: Request, socket: Socket, options: { headers?: NodeJS.Dict<string> } = {}) {
+    async forwardWebsocket(
+        req: Request,
+        socket: Socket,
+        options: { headers?: NodeJS.Dict<string>; head?: Buffer } = {}
+    ) {
         const target = new ProxySocket(req, socket, this.options);
-        target.handleWebsocket(options.headers);
+        target.handleWebsocket(options.headers, options.head);
     }
 
     async forwardRequest(req: Request, res: ServerResponse, options: { headers?: NodeJS.Dict<string> } = {}) {

--- a/libs/api-gateway/proxy/proxy-socket.spec.ts
+++ b/libs/api-gateway/proxy/proxy-socket.spec.ts
@@ -56,3 +56,78 @@ describe('ProxySocket.createHttpHeader', () => {
         expect(proxySocket.createHttpHeader('HTTP/1.1 200 OK', {})).toBe('HTTP/1.1 200 OK\r\n\r\n');
     });
 });
+
+describe('ProxySocket upgrade head', () => {
+    /**
+     * Node hands over any upgraded-protocol bytes its HTTP parser consumed alongside the
+     * handshake. Those bytes are already out of the stream, so they must be pushed back
+     * before the sockets are piped or the first frame is lost — for a server that speaks
+     * first, that is the whole handshake.
+     */
+    function socketDouble() {
+        return {
+            setTimeout: jest.fn(),
+            setNoDelay: jest.fn(),
+            setKeepAlive: jest.fn(),
+            write: jest.fn(),
+            unshift: jest.fn(),
+            end: jest.fn(),
+            on: jest.fn(),
+            pipe: jest.fn().mockReturnValue({ pipe: jest.fn() }),
+            destroyed: false
+        };
+    }
+
+    function upgrade(proxyHead: Buffer, clientHead?: Buffer) {
+        const clientSocket = socketDouble();
+        const proxySocket = socketDouble();
+        const proxySocketInstance = createProxySocket(
+            { method: 'GET', url: '/socket.io/', headers: { upgrade: 'websocket' } },
+            clientSocket as never
+        );
+
+        proxySocketInstance['clientHead'] = clientHead;
+        proxySocketInstance['onUpgrade'](
+            { headers: { upgrade: 'websocket' } } as never,
+            proxySocket as never,
+            proxyHead
+        );
+
+        return { clientSocket, proxySocket };
+    }
+
+    it('replays the upstream head so a server-spoken first frame survives', () => {
+        const openPacket = Buffer.from('\x81\x6d0{"sid":"abc","pingInterval":25000}');
+        expect(upgrade(openPacket).proxySocket.unshift).toHaveBeenCalledWith(openPacket);
+    });
+
+    it('replays the upstream head before wiring the pipes', () => {
+        const { proxySocket } = upgrade(Buffer.from('frame'));
+        expect(proxySocket.unshift.mock.invocationCallOrder[0]).toBeLessThan(
+            proxySocket.pipe.mock.invocationCallOrder[0]
+        );
+    });
+
+    it('replays the client head onto the client socket', () => {
+        const clientHead = Buffer.from('early-client-frame');
+        expect(upgrade(Buffer.alloc(0), clientHead).clientSocket.unshift).toHaveBeenCalledWith(clientHead);
+    });
+
+    it('does not replay an absent or empty head', () => {
+        const { clientSocket, proxySocket } = upgrade(Buffer.alloc(0));
+        expect(proxySocket.unshift).not.toHaveBeenCalled();
+        expect(clientSocket.unshift).not.toHaveBeenCalled();
+    });
+
+    it('retains the client head handed to handleWebsocket', () => {
+        const clientHead = Buffer.from('pipelined');
+        const proxySocketInstance = createProxySocket(
+            { method: 'GET', url: '/socket.io/', headers: { upgrade: 'websocket' } },
+            socketDouble() as never
+        );
+
+        proxySocketInstance.handleWebsocket({}, clientHead);
+
+        expect(proxySocketInstance['clientHead']).toBe(clientHead);
+    });
+});

--- a/libs/api-gateway/proxy/proxy-socket.ts
+++ b/libs/api-gateway/proxy/proxy-socket.ts
@@ -5,6 +5,9 @@ import { ProxyServerOptions } from './proxy-server-option.type';
 import { IncomingMessage } from 'http';
 
 export class ProxySocket {
+    /** Bytes of the upgraded protocol that the HTTP parser consumed alongside the client handshake. */
+    private clientHead?: Buffer;
+
     constructor(
         private req: Request,
         private socket: Socket,
@@ -42,10 +45,11 @@ export class ProxySocket {
         );
     }
 
-    handleWebsocket(extraHeaders: NodeJS.Dict<string> = {}) {
+    handleWebsocket(extraHeaders: NodeJS.Dict<string> = {}, head?: Buffer) {
         if (!this.checkMethodAndHeader()) {
             return this.socket.destroy();
         }
+        this.clientHead = head;
         const url = new URL(this.options.host);
         const requestOptions: http.RequestOptions = {
             method: this.req.method,
@@ -81,6 +85,21 @@ export class ProxySocket {
         proxySocket.on('close', () => {
             this.socket.end();
         });
+
+        // Node's HTTP parser reads in whole chunks, so bytes belonging to the upgraded
+        // protocol can be consumed along with the handshake and handed over as a head
+        // buffer. They are already out of the stream, so piping alone would drop them —
+        // push each head back to the front of its socket before the pipes are wired.
+        // Servers that speak first (Engine.IO sends its OPEN packet immediately) lose
+        // that first frame otherwise, leaving a connection that looks live but never
+        // completes its handshake.
+        if (proxyHead?.length) {
+            proxySocket.unshift(proxyHead);
+        }
+
+        if (this.clientHead?.length) {
+            this.socket.unshift(this.clientHead);
+        }
 
         this.socket.write(this.createHttpHeader('HTTP/1.1 101 Switching Protocols', proxyRes.headers));
 

--- a/libs/api-gateway/restful/services/proxy.service.ts
+++ b/libs/api-gateway/restful/services/proxy.service.ts
@@ -49,9 +49,9 @@ export class ProxyService implements OnModuleInit {
      */
     onModuleInit(): void {
         const serverInstance = this.adapterHost.httpAdapter;
-        serverInstance.getHttpServer().on('upgrade', async (request, socket) => {
+        serverInstance.getHttpServer().on('upgrade', async (request, socket, head) => {
             try {
-                await this.handleWebSocketRequest(request, socket);
+                await this.handleWebSocketRequest(request, socket, head);
             } catch (e) {
                 console.error(e);
             }
@@ -212,15 +212,17 @@ export class ProxyService implements OnModuleInit {
      * validate the WebSocket token, and forwards the request to the appropriate server with any necessary headers
      * @param {Request} request A request
      * @param {Socket} socket A socket
+     * @param {Buffer} head Upgraded-protocol bytes the HTTP parser consumed with the handshake
      */
-    private async handleWebSocketRequest(request: Request, socket: Socket): Promise<void> {
+    private async handleWebSocketRequest(request: Request, socket: Socket, head?: Buffer): Promise<void> {
         const serverName = this.getServerName(request.url);
         const proxyRequest = new ProxyRequest();
         if (!(await this.wsRequestService.handle(request, proxyRequest))) {
             throw new ForbiddenException();
         }
         await this.proxyServers[serverName].forwardWebsocket(request, socket, {
-            headers: proxyRequest.getKebabHeaders()
+            headers: proxyRequest.getKebabHeaders(),
+            head
         });
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@hodfords/nestjs-api-gateway",
-    "version": "11.0.40",
+    "version": "11.0.41",
     "description": "The API Gateway houses the source code and documentation for the API Gateway - a powerful and versatile solution for managing and deploying APIs within a distributed and microservices-oriented architecture.",
     "author": "",
     "private": false,


### PR DESCRIPTION
## Problem

The WebSocket proxy receives the upgrade `head` from Node and discards it:

```ts
private onUpgrade(proxyRes: Request, proxySocket: Socket, proxyHead: Buffer) {
    proxySocket.on('close', () => { this.socket.end(); });
    this.socket.write(this.createHttpHeader('HTTP/1.1 101 Switching Protocols', proxyRes.headers));
    proxySocket.pipe(this.socket).pipe(proxySocket);   // proxyHead never used
}
```

Node's HTTP parser reads in whole chunks. Bytes belonging to the upgraded protocol can be consumed alongside the handshake, and the parser hands them back as `head` because it cannot push them into the stream itself. They are already out of the stream, so piping alone drops them.

**A server that speaks first loses its opening frame.** Engine.IO writes its `0{...}` OPEN packet immediately on connection, so it frequently lands in the same TCP read as the `101`. Dumping the head against a live Engine.IO backend shows exactly that:

```
proxyHead = 109 bytes -> "0{\"sid\":\"JBPb7byiNoeOsQ1uAA35\",\"upgrades\":[],\"pingInterval\":25000,...
proxyHead có dữ liệu: 11/25   rỗng: 14/25
```

Everything after that first read still pipes normally, so an affected connection looks alive and keeps answering pings at the 25s interval — it just never completes its handshake and can never authenticate or join a room. Whether the two coalesce is a timing race, which is why the failure is intermittent and gets much worse as connection burst rate rises.

## Fix

Push each head back to the front of its socket before wiring the pipes, the same way `http-proxy` does. Ordering matters: the `unshift` must precede the `pipe`.

The client-side head is now threaded through the upgrade handler too (`proxy.service.ts` → `forwardWebsocket` → `handleWebsocket`). It is unused by clients that wait for the `101` before sending, but was dropped by the same omission.

## Verification

Layer isolation against a live deployment — the backend is healthy, the proxy is not:

| Target | OPEN frame received |
|---|---|
| Engine.IO service (direct) | 12 / 12 |
| gateway (direct, single pod) | 4 / 12 |

Running this branch's build against the same live backend:

| Build | OPEN frame, burst 40 | 50 concurrent clients, full connect + auth + join |
|---|---|---|
| `11.0.40` | ~5 / 40 | 28 / 50 (56%) |
| this branch | **40 / 40** | **50 / 50 (100%)** |

## Tests

5 regression tests in `proxy-socket.spec.ts` cover both heads, the replay-before-pipe ordering, and the empty-head case. Reverting the fix with the tests in place fails 3 of them, so they genuinely pin the behaviour.

Full suite: 167 passed / 18 suites. Lint clean, build passes. Pre-existing `tsc` error count is unchanged (15 before and after).