### PR TITLE
fix(proxy): keep the upgrade off the keep-alive agent so tunnels are not reclaimed

### DIFF
--- a/libs/api-gateway/proxy/proxy-socket.spec.ts
+++ b/libs/api-gateway/proxy/proxy-socket.spec.ts
@@ -131,3 +131,52 @@ describe('ProxySocket upgrade head', () => {
         expect(proxySocketInstance['clientHead']).toBe(clientHead);
     });
 });
+
+describe('ProxySocket upstream idle timer', () => {
+    /**
+     * A socket taken from the keep-alive pool carries the agent's idle timeout, already
+     * partly elapsed. That timer outlives the protocol handover, so a quiet tunnel gets
+     * reclaimed mid-session. The upgrade must never use a pooled socket, and the
+     * upstream socket's timeout must be cleared exactly as the client's is.
+     */
+    it('opts out of the keep-alive agent for the upgrade request', () => {
+        const options = createProxySocket({
+            method: 'GET',
+            url: '/socket.io/?EIO=4&transport=websocket',
+            headers: { upgrade: 'websocket' }
+        }).buildRequestOptions();
+
+        expect(options.agent).toBe(false);
+    });
+
+    it('still forwards path, method and merged headers', () => {
+        const options = createProxySocket({
+            method: 'GET',
+            url: '/socket.io/?EIO=4',
+            headers: { upgrade: 'websocket', cookie: 'a=1' }
+        }).buildRequestOptions({ 'auth-user-id': 'u-1' });
+
+        expect(options.path).toBe('/socket.io/?EIO=4');
+        expect(options.method).toBe('GET');
+        expect(options.headers).toMatchObject({ upgrade: 'websocket', cookie: 'a=1', 'auth-user-id': 'u-1' });
+        expect(options.port).toBe('18080');
+    });
+
+    it('clears the inherited idle timeout on the upstream socket before piping', () => {
+        const proxySocket = { on: jest.fn(), setTimeout: jest.fn(), unshift: jest.fn(), pipe: jest.fn() };
+        proxySocket.pipe.mockReturnValue({ pipe: jest.fn() });
+        const clientSocket = {
+            write: jest.fn(),
+            unshift: jest.fn(),
+            pipe: jest.fn().mockReturnValue({ pipe: jest.fn() })
+        };
+
+        const instance = createProxySocket({ method: 'GET', url: '/', headers: {} }, clientSocket as never);
+        instance['onUpgrade']({ headers: {} } as never, proxySocket as never, Buffer.alloc(0));
+
+        expect(proxySocket.setTimeout).toHaveBeenCalledWith(0);
+        expect(proxySocket.setTimeout.mock.invocationCallOrder[0]).toBeLessThan(
+            proxySocket.pipe.mock.invocationCallOrder[0]
+        );
+    });
+});

--- a/libs/api-gateway/proxy/proxy-socket.ts
+++ b/libs/api-gateway/proxy/proxy-socket.ts
@@ -45,13 +45,10 @@ export class ProxySocket {
         );
     }
 
-    handleWebsocket(extraHeaders: NodeJS.Dict<string> = {}, head?: Buffer) {
-        if (!this.checkMethodAndHeader()) {
-            return this.socket.destroy();
-        }
-        this.clientHead = head;
+    buildRequestOptions(extraHeaders: NodeJS.Dict<string> = {}): http.RequestOptions {
         const url = new URL(this.options.host);
-        const requestOptions: http.RequestOptions = {
+
+        return {
             method: this.req.method,
             host: url.host,
             hostname: url.hostname,
@@ -60,9 +57,23 @@ export class ProxySocket {
                 ...this.req.headers,
                 ...extraHeaders
             },
-            path: this.req.url
+            path: this.req.url,
+            // Never borrow a socket from the keep-alive pool for an upgrade. A pooled
+            // socket arrives with the agent's idle timeout already armed and partly
+            // elapsed, and that timer survives the handover to the upgraded protocol —
+            // the tunnel then dies mid-session once the peers go quiet, which for
+            // Engine.IO is the 25s gap between pings. An upgrade needs a socket the
+            // agent will never reclaim.
+            agent: false
         };
-        const proxyReq = http.request(requestOptions);
+    }
+
+    handleWebsocket(extraHeaders: NodeJS.Dict<string> = {}, head?: Buffer) {
+        if (!this.checkMethodAndHeader()) {
+            return this.socket.destroy();
+        }
+        this.clientHead = head;
+        const proxyReq = http.request(this.buildRequestOptions(extraHeaders));
         this.socket.setTimeout(0);
         this.socket.setNoDelay(true);
         this.socket.setKeepAlive(true, 0);
@@ -93,6 +104,10 @@ export class ProxySocket {
         // Servers that speak first (Engine.IO sends its OPEN packet immediately) lose
         // that first frame otherwise, leaving a connection that looks live but never
         // completes its handshake.
+        // The client socket is cleared the same way in handleWebsocket; do the same
+        // upstream so no inherited idle timer can reclaim the tunnel.
+        proxySocket.setTimeout(0);
+
         if (proxyHead?.length) {
             proxySocket.unshift(proxyHead);
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@hodfords/nestjs-api-gateway",
-    "version": "11.0.41",
+    "version": "11.0.42",
     "description": "The API Gateway houses the source code and documentation for the API Gateway - a powerful and versatile solution for managing and deploying APIs within a distributed and microservices-oriented architecture.",
     "author": "",
     "private": false,


### PR DESCRIPTION
Follow-up to #36, found while load testing the same deployment.

## Problem

`handleWebsocket` builds its upstream request without naming an agent, so it goes out through `http.globalAgent` — which since Node 19 is `{ keepAlive: true, timeout: 5000 }`. A socket taken from that pool arrives with the idle timer already running and partly elapsed, and **the timer survives the handover to the upgraded protocol**. Nothing clears it: the code carefully calls `setTimeout(0)` on the client socket, but never on the upstream one.

The tunnel is then reclaimed once both peers go quiet. Engine.IO leaves a 25s gap between pings, so an idle session sits well inside the window — it completes connect, authentication and its room joins, then dies a few seconds later with no close frame.

Only connections that happen to reuse a pooled socket are affected. That explains both the low rate and the scatter in the deadline: a socket that idled 1s in the pool brings a 4000ms timer, not 5000ms.

## Evidence

Sessions dying mid-hold, measured from inside the cluster so nginx and HAProxy are out of the path entirely:

| Target | Dropped |
|---|---|
| Engine.IO service directly, authenticated + rooms joined | 0 / 200 |
| gateway directly, bypassing ingress and load balancer | **2 / 200** at 5.04s and 5.08s |

Sending any frame every 2s suppresses it completely (0/60 vs 2/60 idle) — consistent with an idle timer being reset.

`socket.timeout` observed on upgraded sockets with a warm pool:

```
before  [4000, null, 5000, 5000, null, 5000, 5000, ...]   ~half of connections
after   [null, null, null, null, null, null, null, ...]   every connection
```

## Fix

Opt the upgrade out of the agent (`agent: false`) and clear the upstream socket's timeout alongside the client's. Request options move into `buildRequestOptions()` so the agent choice is directly assertable — spying on the `node:http` namespace does not intercept the call.

## Honest scope

This provably removes the inherited timer, and that is the only mechanism I could find matching all three observed properties (4–6s deadline, a few percent of sessions, suppressed by traffic). I could **not** reproduce the drop in a local harness, so there is no end-to-end A/B proving it eliminates the production drops — that needs a deploy.

Worth noting for whoever verifies: at a ~1–2% rate a 40-connection sample proves nothing. Use **200+ connections** held past 10s. Several of my own earlier conclusions were wrong precisely because the samples were too small.

## Tests

3 new tests covering the agent opt-out, the preserved request options, and clearing the upstream timeout before piping. Reverting the fix fails 2 of them.

Full suite: 170 passed / 18 suites. Lint clean, build passes.